### PR TITLE
add check for logarithmic x axis to labelLines

### DIFF
--- a/labellines/core.py
+++ b/labellines/core.py
@@ -90,7 +90,11 @@ def labelLines(lines, align=True, xvals=None, **kwargs):
         xvals = np.linspace(xvals[0], xvals[1], len(labLines)+2)[1:-1]
     elif xvals is None:
         xmin, xmax = ax.get_xlim()
-        xvals = np.linspace(xmin, xmax, len(labLines)+2)[1:-1]
+        xscale = ax.get_xscale()
+        if xscale == "log":
+            xvals = np.logspace(np.log10(xmin), np.log10(xmax), len(labLines)+2)[1:-1]
+        else:
+            xvals = np.linspace(xmin, xmax, len(labLines)+2)[1:-1]
 
     for line, x, label in zip(labLines, xvals, labels):
         labelLine(line, x, label, align, **kwargs)


### PR DESCRIPTION
Hi,

first things first: great little tool - thanks!

PR: I found myself needing to use this on a plot with a logarithmic x axis, which breaks the automatic distribution of the labels, since this happens linearly. So I simply added a quick check for the scaling of the x axis and implemented a fix for the case of "log" scaling. For all other cases the behavior is the same as before. (this means that "symlog" and "logit" scaling will still have problems, but I didn't have a quick fix on my mind right now, may have another look another time.)

Cheers