### PR TITLE
Move labels farther from the left and right edges of the plot

### DIFF
--- a/labellines/core.py
+++ b/labellines/core.py
@@ -48,7 +48,7 @@ def labelLine(line, x, label=None, align=True, drop_label=False, **kwargs):
 
     def x_to_float(x):
         """Make sure datetime values are properly converted to floats."""
-v        return date2num(x) if isinstance(x, datetime) else x
+        return date2num(x) if isinstance(x, datetime) else x
 
     xfa = x_to_float(xa)
     xfb = x_to_float(xb)

--- a/labellines/core.py
+++ b/labellines/core.py
@@ -48,7 +48,7 @@ def labelLine(line, x, label=None, align=True, drop_label=False, **kwargs):
 
     def x_to_float(x):
         """Make sure datetime values are properly converted to floats."""
-        return date2num(x) if isinstance(x, datetime) else x
+v        return date2num(x) if isinstance(x, datetime) else x
 
     xfa = x_to_float(xa)
     xfb = x_to_float(xb)
@@ -137,6 +137,10 @@ def labelLines(lines, align=True, xvals=None, drop_label=False, **kwargs):
 
     if xvals is None:
         xvals = ax.get_xlim()  # set axis limits as annotation limits, xvals now a tuple
+        SHRINK_FACTOR = 0.05  # How far out (relatively) from the edges to place closest labels.
+        xvals_rng = xvals[1] - xvals[0]
+        shrinkage = xvals_rng * SHRINK_FACTOR
+        xvals = (xvals[0] + shrinkage, xvals[1] - shrinkage)
     if type(xvals) == tuple:
         xmin, xmax = xvals
         xscale = ax.get_xscale()

--- a/labellines/core.py
+++ b/labellines/core.py
@@ -97,7 +97,7 @@ v        return date2num(x) if isinstance(x, datetime) else x
     ax.text(x, y, label, rotation=rotation, **kwargs)
 
 
-def labelLines(lines, align=True, xvals=None, drop_label=False, **kwargs):
+def labelLines(lines, align=True, xvals=None, drop_label=False, shrink_factor=0.05, **kwargs):
     '''Label all lines with their respective legends.
 
     Parameters
@@ -113,6 +113,8 @@ def labelLines(lines, align=True, xvals=None, drop_label=False, **kwargs):
     drop_label : bool, optional
        If True, the label is consumed by the function so that subsequent calls to e.g. legend
        do not use it anymore.
+    shrink_factor : double, optional
+       Relative distance from the edges to place closest labels. Defaults to 0.05.
     kwargs : dict, optional
        Optional arguments passed to ax.text
     '''
@@ -137,9 +139,8 @@ def labelLines(lines, align=True, xvals=None, drop_label=False, **kwargs):
 
     if xvals is None:
         xvals = ax.get_xlim()  # set axis limits as annotation limits, xvals now a tuple
-        SHRINK_FACTOR = 0.05  # How far out (relatively) from the edges to place closest labels.
         xvals_rng = xvals[1] - xvals[0]
-        shrinkage = xvals_rng * SHRINK_FACTOR
+        shrinkage = xvals_rng * shrink_factor
         xvals = (xvals[0] + shrinkage, xvals[1] - shrinkage)
     if type(xvals) == tuple:
         xmin, xmax = xvals


### PR DESCRIPTION
Fixes #20, and makes `shrink_factor` an argument to `labelLines()` defaulting to 0.05; i.e., the leftmost and rightmost labels will each be placed 5% of the plot width in from the plot edges.