### PR TITLE
Allow xvalues to be _at_ the edge

### DIFF
--- a/labellines/core.py
+++ b/labellines/core.py
@@ -249,6 +249,15 @@ def labelLines(
         # Move xlabel if it is outside valid range
         xdata = ensure_float(line.get_xdata())
         if not (min(xdata) <= xv <= max(xdata)):
+            warnings.warn(
+                (
+                    "The value at position %s in `xvals` is outside the range of its "
+                    "associated line (xmin=%s, xmax=%s, xval=%s). Clipping it "
+                    "into the allowed range."
+                )
+                % (i, min(xdata), max(xdata), xv),
+                UserWarning,
+            )
             new_xv = min(xdata) + (max(xdata) - min(xdata)) * 0.9
             xvals[i] = new_xv
 

--- a/labellines/core.py
+++ b/labellines/core.py
@@ -245,7 +245,7 @@ def labelLines(
 
         # Move xlabel if it is outside valid range
         xdata = ensure_float(line.get_xdata())
-        if not (min(xdata) < xv < max(xdata)):
+        if not (min(xdata) <= xv <= max(xdata)):
             new_xv = min(xdata) + (max(xdata) - min(xdata)) * 0.9
             xvals[i] = new_xv
 

--- a/labellines/core.py
+++ b/labellines/core.py
@@ -5,6 +5,7 @@ import matplotlib.patheffects as path_effects
 import numpy as np
 from matplotlib.container import ErrorbarContainer
 from matplotlib.dates import DateConverter, num2date
+from more_itertools import always_iterable
 
 from .utils import ensure_float, maximum_bipartite_matching
 
@@ -235,6 +236,8 @@ def labelLines(
             # Now reorder the xvalues
             old_xvals = xvals.copy()
             xvals[order] = old_xvals
+    else:
+        xvals = list(always_iterable(xvals))  # force the creation of a copy
 
     labLines, labels = [], []
     # Take only the lines which have labels other than the default ones

--- a/labellines/test.py
+++ b/labellines/test.py
@@ -299,3 +299,27 @@ def test_auto_layout(setupMpl):
 
     labelLines(lines)
     return plt.gcf()
+
+
+def test_warning_out_of_range():
+    X = [0, 1]
+    Y = [0, 1]
+
+    lines = plt.plot(X, Y, label="test")
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "The value at position 0 in `xvals` is outside the range of its "
+            "associated line"
+        ),
+    ):
+        labelLines(lines, xvals=[-1])
+
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "The value at position 0 in `xvals` is outside the range of its "
+            "associated line"
+        ),
+    ):
+        labelLines(lines, xvals=[2])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,8 @@ known_third_party = [
 ]
 known_first_party = ["labellines"]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
 packages = find:
 install_requires =
     matplotlib>=2.0.2
+    more-itertools
     numpy>=1.13.3
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
This fixes #68 by allowing `xvals` to be right at the edge.